### PR TITLE
Honour the X_FORWARDED_FOR header if it exists, otherwise REMOTE_ADDR.

### DIFF
--- a/add.php
+++ b/add.php
@@ -52,7 +52,8 @@ if ( isset($_POST['email']) && !empty($_POST['email']) && isset($_POST['domains'
     echo "Email: " . htmlspecialchars($email) . ".<br>";
     echo "</div>";
     foreach ($domains['domains'] as $key => $value) {
-      $add_domain = add_domain_to_pre_check($value, $email, $_SERVER['REMOTE_ADDR']);
+      $userip = $_SERVER["HTTP_X_FORWARDED_FOR"] ? $_SERVER["HTTP_X_FORWARDED_FOR"] : $_SERVER["REMOTE_ADDR"];
+      $add_domain = add_domain_to_pre_check($value, $email, $userip);
       if (is_array($add_domain["errors"]) && count($add_domain["errors"]) != 0) {
         $errors = array_unique($add_domain["errors"]);
         foreach ($add_domain["errors"] as $key => $err_value) {

--- a/confirm.php
+++ b/confirm.php
@@ -25,7 +25,8 @@ if ( isset($_GET['id']) && !empty($_GET['id'])  ) {
   $id = htmlspecialchars($_GET['id']);
   $uuid_pattern = "/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/";
   if (preg_match($uuid_pattern, $id)) {
-    $add_domain = add_domain_check($id, $_SERVER['REMOTE_ADDR']);
+    $userip = $_SERVER["HTTP_X_FORWARDED_FOR"] ? $_SERVER["HTTP_X_FORWARDED_FOR"] : $_SERVER["REMOTE_ADDR"];
+    $add_domain = add_domain_check($id, $userip);
     if (is_array($add_domain["errors"]) && count($add_domain["errors"]) != 0) {
       $errors = array_unique($add_domain["errors"]);
       foreach ($add_domain["errors"] as $key => $err_value) {

--- a/unsubscribe.php
+++ b/unsubscribe.php
@@ -24,7 +24,7 @@ require('inc/header.php');
 
 if ( isset($_GET['id']) && !empty($_GET['id'])  ) {
   $id = htmlspecialchars($_GET['id']);
-  $userip = $_SERVER['REMOTE_ADDR'];
+  $userip = $_SERVER["HTTP_X_FORWARDED_FOR"] ? $_SERVER["HTTP_X_FORWARDED_FOR"] : $_SERVER["REMOTE_ADDR"];
   if ( isset($_GET['cron']) && !empty($_GET['cron'])  ) {
     $cron = htmlspecialchars($_GET['cron']);
   } 


### PR DESCRIPTION
If the site is hosted behind Cloudflare (probably other reverse proxies too) the REMOTE_ADDR does not contain the real user IP address, so emails show the wrong IP address.

But CF does set the "well-established" X-Forwarder-For header (https://support.cloudflare.com/hc/en-us/articles/200170986), so use this instead if it exists.