### PR TITLE
Allow confirm/unsub links to not match email domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ First get the code and unpack it to your webroot:
 
 Create the database files, outside of your webroot. If you create these inside your webroot, everybody can read them.
 
-  touch /var/www/certificate-expiry-monitor-db/pre_checks.json
-  touch /var/www/certificate-expiry-monitor-db/checks.json
-  touch /var/www/certificate-expiry-monitor-db/deleted_checks.json
-  chown -R $wwwuser /var/www/certificate-expiry-monitor-db/*.json
+    touch /var/www/certificate-expiry-monitor-db/pre_checks.json
+    touch /var/www/certificate-expiry-monitor-db/checks.json
+    touch /var/www/certificate-expiry-monitor-db/deleted_checks.json
+    chown -R $wwwuser /var/www/certificate-expiry-monitor-db/*.json
 
 These files are used by the tool as database for checks.
 
@@ -36,9 +36,9 @@ Change the location of these files in `variables.php`:
 
     // set this to a location outside of your webroot so that it cannot be accessed via the internets.
 
-    $pre_check_file = '/var/ww/html/certificate-expiry-monitor/pre_checks.json';
-    $check_file = '/var/ww/html/certificate-expiry-monitor/checks.json';
-    $deleted_check_file = '/var/ww/html/certificate-expiry-monitor/deleted_checks.json';
+    $pre_check_file = '/var/www/html/certificate-expiry-monitor/pre_checks.json';
+    $check_file = '/var/www/html/certificate-expiry-monitor/checks.json';
+    $deleted_check_file = '/var/www/html/certificate-expiry-monitor/deleted_checks.json';
 
 Also change the `$current_domain` variable, it is used in all the email addresses.
 
@@ -51,8 +51,8 @@ And `$current_link`, which may or may not be the same. It is used in the confirm
 Set up the cronjob to run once a day:
 
     # /etc/cron.d/certificate-exipry-monitor
-    1 1 * * * $wwwuser /path/to/php /var/ww/html/certificate-expiry-monitor/cron.php >> /var/log/certificate-expiry-monitor.log 2>&1
+    1 1 * * * $wwwuser /path/to/php /var/www/html/certificate-expiry-monitor/cron.php >> /var/log/certificate-expiry-monitor.log 2>&1
 
 
-The default timeout for checks is 2 seconds. If this is to fast for your internal services, this can be raised in the `variables.php` file.
+The default timeout for checks is 2 seconds. If this is too fast for your internal services, this can be raised in the `variables.php` file.
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,13 @@ Change the location of these files in `variables.php`:
     $check_file = '/var/ww/html/certificate-expiry-monitor/checks.json';
     $deleted_check_file = '/var/ww/html/certificate-expiry-monitor/deleted_checks.json';
 
-Also change the `$current_domain` variable, it is used in all the emails.
+Also change the `$current_domain` variable, it is used in all the email addresses.
 
     $current_domain = "certificatemonitor.org";
+
+And `$current_link`, which may or may not be the same. It is used in the confirm and unsubscribe links, and depends on your webserver configuration. `example.com/subdir` here means your unsubscribe links will start `https://example.com/subdir/unsubscribe.php`.
+
+    $current_link = "certificatemonitor.org";
 
 Set up the cronjob to run once a day:
 

--- a/cron.php
+++ b/cron.php
@@ -124,7 +124,7 @@ if (php_sapi_name() == "cli") {
   if ( count($removal_queue) != 0 ) {
     echo "Processing removal queue.\n";
     foreach ($removal_queue as $remove_key => $remove_value) {
-      $unsub_url = "https://" . $current_domain . "/unsubscribe.php?cron=auto&id=" . $remove_value;
+      $unsub_url = "https://" . $current_link . "/unsubscribe.php?cron=auto&id=" . $remove_value;
       $file = file_get_contents($unsub_url);
       if ($file === FALSE) {
         $error = error_get_last();

--- a/functions/add_check.php
+++ b/functions/add_check.php
@@ -16,6 +16,7 @@
 
 function add_domain_check($id,$visitor_ip) {
     global $current_domain;
+    global $current_link;
     global $pre_check_file;
     global $check_file;
     $result = array();
@@ -89,7 +90,7 @@ function add_domain_check($id,$visitor_ip) {
         return $result;
     }
 
-    $unsublink = "https://" . $current_domain . "/unsubscribe.php?id=" . $id;
+    $unsublink = "https://" . $current_link . "/unsubscribe.php?id=" . $id;
 
     $to      = $json_a[$id]['email'];
     $subject = "Certificate Expiry Monitor subscription confirmed for " . htmlspecialchars($json_a[$id]['domain']) . ".";
@@ -102,7 +103,7 @@ Email  : " . trim(htmlspecialchars($json_a[$id]['email'])) . "
 IP subscription confirmed from: " . htmlspecialchars($visitor_ip) . "
 Date subscribed confirmed: " . date("Y-m-d H:i:s T") . "
 
-We will monitor the certificates for this website. You will receive emails when it is about to expire as described in the FAQ on our website. You can view the FAQ here: https://" . $current_domain . ".
+We will monitor the certificates for this website. You will receive emails when it is about to expire as described in the FAQ on our website. You can view the FAQ here: https://" . $current_link . ".
 
 To unsubscribe from notifications for this domain please click or copy and paste the below link in your browser:
 
@@ -110,14 +111,14 @@ To unsubscribe from notifications for this domain please click or copy and paste
 
 Have a nice day,
 The Certificate Expiry Monitor Service.
-https://" . $current_domain . "";
+https://" . $current_link . "";
     $message = wordwrap($message, 70, "\r\n");
     $headers = 'From: noreply@' . $current_domain . "\r\n" .
         'Reply-To: noreply@' . $current_domain . "\r\n" .
         'Return-Path: noreply@' . $current_domain . "\r\n" .
         'X-Visitor-IP: ' . $visitor_ip . "\r\n" .
         'X-Coffee: Black' . "\r\n" .
-        'List-Unsubscribe: <https://' . $current_domain . "/unsubscribe.php?id=" . $id . ">" . "\r\n" .
+        'List-Unsubscribe: <https://' . $current_link . "/unsubscribe.php?id=" . $id . ">" . "\r\n" .
         'X-Mailer: PHP/4.1.1';
 
     

--- a/functions/email.php
+++ b/functions/email.php
@@ -25,6 +25,7 @@ function validate_email($email) {
 function send_error_mail($domain, $email, $errors) {
   echo "\t\tSending error mail to $email for $domain.\n";
   global $current_domain;
+  global $current_link;
   global $check_file;
   $domain = trim($domain);
   $errors = implode("\r\n", $errors);
@@ -43,17 +44,17 @@ function send_error_mail($domain, $email, $errors) {
     if ($value["domain"] == $domain && $value["email"] == $email) {
       $id = $key;
       $failures = $value['errors'];
-      $unsublink = "https://" . $current_domain . "/unsubscribe.php?id=" . $id;
+      $unsublink = "https://" . $current_link . "/unsubscribe.php?id=" . $id;
       $to      = $email;
       $subject = "Certificate monitor " . htmlspecialchars($domain) . " failed.";
-      $message = "Hello,\r\n\r\nYou have a subscription to monitor the certificate of " . htmlspecialchars($domain) . " with the the Certificate Expiry Monitor. This is a service which monitors an SSL certificate on a website, and notifies you when it is about to expire. This extra notification helps you remember to renew your certificate on time.\r\n\r\nWe've noticed that the check for the following domain has failed: \r\n\r\nDomain: " . htmlspecialchars($domain) . "\r\nError(s): " . htmlspecialchars($errors) . "\r\n\r\nFailure(s): " . htmlspecialchars($failures) . "\r\n\r\nPlease check this website or it's certificate. If the check fails 7 times we will remove it from our monitoring. If the check succeeds again within 7 failures, the failure count will reset.\r\n\r\nTo unsubscribe from notifications for this domain please click or copy and paste the below link in your browser:\r\n\r\n" . $unsublink . "\r\n\r\n\r\n Have a nice day,\r\nThe Certificate Expiry Monitor Service.\r\nhttps://" . $current_domain . "";
+      $message = "Hello,\r\n\r\nYou have a subscription to monitor the certificate of " . htmlspecialchars($domain) . " with the the Certificate Expiry Monitor. This is a service which monitors an SSL certificate on a website, and notifies you when it is about to expire. This extra notification helps you remember to renew your certificate on time.\r\n\r\nWe've noticed that the check for the following domain has failed: \r\n\r\nDomain: " . htmlspecialchars($domain) . "\r\nError(s): " . htmlspecialchars($errors) . "\r\n\r\nFailure(s): " . htmlspecialchars($failures) . "\r\n\r\nPlease check this website or it's certificate. If the check fails 7 times we will remove it from our monitoring. If the check succeeds again within 7 failures, the failure count will reset.\r\n\r\nTo unsubscribe from notifications for this domain please click or copy and paste the below link in your browser:\r\n\r\n" . $unsublink . "\r\n\r\n\r\n Have a nice day,\r\nThe Certificate Expiry Monitor Service.\r\nhttps://" . $current_link . "";
       $message = wordwrap($message, 70, "\r\n");
       $headers = 'From: noreply@' . $current_domain . "\r\n" .
           'Reply-To: noreply@' . $current_domain . "\r\n" .
           'Return-Path: noreply@' . $current_domain . "\r\n" .
           'X-Visitor-IP: ' . $visitor_ip . "\r\n" .
           'X-Coffee: Black' . "\r\n" .
-          'List-Unsubscribe: <https://' . $current_domain . "/unsubscribe.php?id=" . $id . ">" . "\r\n" .
+          'List-Unsubscribe: <https://' . $current_link . "/unsubscribe.php?id=" . $id . ">" . "\r\n" .
           'X-Mailer: PHP/4.1.1';  
 
       if (mail($to, $subject, $message, $headers) === true) {
@@ -69,6 +70,7 @@ function send_error_mail($domain, $email, $errors) {
 
 function send_cert_expired_email($days, $domain, $email, $raw_cert) {
   global $current_domain;
+  global $current_link;
   global $check_file;
   $domain = trim($domain);
   echo "\t\tDomain " . $domain . " expired " . $days . " ago.\n";
@@ -101,18 +103,18 @@ function send_cert_expired_email($days, $domain, $email, $raw_cert) {
       $cert_valid_days_ago = floor($datefromdiff/(60*60*24));
       $cert_valid_days_ahead = floor($datetodiff/(60*60*24));
 
-      $unsublink = "https://" . $current_domain . "/unsubscribe.php?id=" . $id;
+      $unsublink = "https://" . $current_link . "/unsubscribe.php?id=" . $id;
 
       $to      = $email;
       $subject = "A certificate for " . htmlspecialchars($domain) . " expired " . htmlspecialchars($days) . " days ago";
-      $message = "Hello,\r\n\r\nYou have a subscription to monitor the certificate of " . htmlspecialchars($domain) . " with the the Certificate Expiry Monitor. This is a service which monitors an SSL certificate on a website, and notifies you when it is about to expire. This extra notification helps you remember to renew your certificate on time.\r\n\r\nWe've noticed that the following domain has a certificate in it's chain that has expired " . htmlspecialchars($days) . " days ago:\r\n\r\nDomain: " . htmlspecialchars($domain) . "\r\nCertificate Common Name: " . htmlspecialchars($cert_cn) . "\r\nCertificate Subject: " . htmlspecialchars($cert_subject) . "\r\nCertificate Serial: " . htmlspecialchars($cert_serial) . "\r\nCertificate Valid From: " . htmlspecialchars(date("Y-m-d  H:i:s T", $cert_validfrom_date)) . " (" . $cert_valid_days_ago . " days ago)\r\nCertificate Valid Until: " . htmlspecialchars(date("Y-m-d  H:i:s T", $cert_expiry_date)) . " (" . $cert_valid_days_ahead . " days ago)\r\n\r\nYou should renew and replace your certificate right now. If you haven't set up the certificate yourself, please forward this email to the person/company that did this for you.\r\n\rThis website is now  non-functional and displays errors to it's users. Please fix this issue as soon as possible.\r\n\r\nTo unsubscribe from notifications for this domain please click or copy and paste the below link in your browser:\r\n\r\n" . $unsublink . "\r\n\r\n\r\n Have a nice day,\r\nThe Certificate Expiry Monitor Service.\r\nhttps://" . $current_domain . "";
+      $message = "Hello,\r\n\r\nYou have a subscription to monitor the certificate of " . htmlspecialchars($domain) . " with the the Certificate Expiry Monitor. This is a service which monitors an SSL certificate on a website, and notifies you when it is about to expire. This extra notification helps you remember to renew your certificate on time.\r\n\r\nWe've noticed that the following domain has a certificate in it's chain that has expired " . htmlspecialchars($days) . " days ago:\r\n\r\nDomain: " . htmlspecialchars($domain) . "\r\nCertificate Common Name: " . htmlspecialchars($cert_cn) . "\r\nCertificate Subject: " . htmlspecialchars($cert_subject) . "\r\nCertificate Serial: " . htmlspecialchars($cert_serial) . "\r\nCertificate Valid From: " . htmlspecialchars(date("Y-m-d  H:i:s T", $cert_validfrom_date)) . " (" . $cert_valid_days_ago . " days ago)\r\nCertificate Valid Until: " . htmlspecialchars(date("Y-m-d  H:i:s T", $cert_expiry_date)) . " (" . $cert_valid_days_ahead . " days ago)\r\n\r\nYou should renew and replace your certificate right now. If you haven't set up the certificate yourself, please forward this email to the person/company that did this for you.\r\n\rThis website is now  non-functional and displays errors to it's users. Please fix this issue as soon as possible.\r\n\r\nTo unsubscribe from notifications for this domain please click or copy and paste the below link in your browser:\r\n\r\n" . $unsublink . "\r\n\r\n\r\n Have a nice day,\r\nThe Certificate Expiry Monitor Service.\r\nhttps://" . $current_link . "";
       $message = wordwrap($message, 70, "\r\n");
       $headers = 'From: noreply@' . $current_domain . "\r\n" .
           'Reply-To: noreply@' . $current_domain . "\r\n" .
           'Return-Path: noreply@' . $current_domain . "\r\n" .
           'X-Visitor-IP: ' . $visitor_ip . "\r\n" .
           'X-Coffee: Black' . "\r\n" .
-          'List-Unsubscribe: <https://' . $current_domain . "/unsubscribe.php?id=" . $id . ">" . "\r\n" .
+          'List-Unsubscribe: <https://' . $current_link . "/unsubscribe.php?id=" . $id . ">" . "\r\n" .
           'X-Mailer: PHP/4.1.1';  
 
       if (mail($to, $subject, $message, $headers) === true) {
@@ -129,6 +131,7 @@ function send_cert_expired_email($days, $domain, $email, $raw_cert) {
 
 function send_expires_in_email($days, $domain, $email, $raw_cert) {
   global $current_domain;
+  global $current_link;
   global $check_file;
   $domain = trim($domain);
   echo "\t\tDomain " . $domain . " expires in " . $days . " days.\n";
@@ -161,18 +164,18 @@ function send_expires_in_email($days, $domain, $email, $raw_cert) {
       $cert_valid_days_ago = floor($datefromdiff/(60*60*24));
       $cert_valid_days_ahead = floor($datetodiff/(60*60*24));
 
-      $unsublink = "https://" . $current_domain . "/unsubscribe.php?id=" . $id;
+      $unsublink = "https://" . $current_link . "/unsubscribe.php?id=" . $id;
 
       $to      = $email;
       $subject = "A certificate for " . htmlspecialchars($domain) . " expires in " . htmlspecialchars($days) . " days";
-      $message = "Hello,\r\n\r\nYou have a subscription to monitor the certificate of " . htmlspecialchars($domain) . " with the the Certificate Expiry Monitor. This is a service which monitors an SSL certificate on a website, and notifies you when it is about to expire. This extra notification helps you remember to renew your certificate on time.\r\n\r\nWe've noticed that the following domain has a certificate in it's chain that will expire in " . htmlspecialchars($days) . " days:\r\n\r\nDomain: " . htmlspecialchars($domain) . "\r\nCertificate Common Name: " . htmlspecialchars($cert_cn) . "\r\nCertificate Subject: " . htmlspecialchars($cert_subject) . "\r\nCertificate Serial: " . htmlspecialchars($cert_serial) . "\r\nCertificate Valid From: " . htmlspecialchars(date("Y-m-d  H:i:s T", $cert_validfrom_date)) . " (" . $cert_valid_days_ago . " days ago)\r\nCertificate Valid Until: " . htmlspecialchars(date("Y-m-d  H:i:s T", $cert_expiry_date)) . " (" . $cert_valid_days_ahead . " days left)\r\n\r\nYou should renew and replace your certificate before it expires. If you haven't set up the certificate yourself, please forward this email to the person/company that did this for you.\r\n\r\nNot replacing your certificate before the expiry date will result in a non-functional website with errors.\r\n\r\nTo unsubscribe from notifications for this domain please click or copy and paste the below link in your browser:\r\n\r\n" . $unsublink . "\r\n\r\n\r\n Have a nice day,\r\nThe Certificate Expiry Monitor Service.\r\nhttps://" . $current_domain . "";
+      $message = "Hello,\r\n\r\nYou have a subscription to monitor the certificate of " . htmlspecialchars($domain) . " with the the Certificate Expiry Monitor. This is a service which monitors an SSL certificate on a website, and notifies you when it is about to expire. This extra notification helps you remember to renew your certificate on time.\r\n\r\nWe've noticed that the following domain has a certificate in it's chain that will expire in " . htmlspecialchars($days) . " days:\r\n\r\nDomain: " . htmlspecialchars($domain) . "\r\nCertificate Common Name: " . htmlspecialchars($cert_cn) . "\r\nCertificate Subject: " . htmlspecialchars($cert_subject) . "\r\nCertificate Serial: " . htmlspecialchars($cert_serial) . "\r\nCertificate Valid From: " . htmlspecialchars(date("Y-m-d  H:i:s T", $cert_validfrom_date)) . " (" . $cert_valid_days_ago . " days ago)\r\nCertificate Valid Until: " . htmlspecialchars(date("Y-m-d  H:i:s T", $cert_expiry_date)) . " (" . $cert_valid_days_ahead . " days left)\r\n\r\nYou should renew and replace your certificate before it expires. If you haven't set up the certificate yourself, please forward this email to the person/company that did this for you.\r\n\r\nNot replacing your certificate before the expiry date will result in a non-functional website with errors.\r\n\r\nTo unsubscribe from notifications for this domain please click or copy and paste the below link in your browser:\r\n\r\n" . $unsublink . "\r\n\r\n\r\n Have a nice day,\r\nThe Certificate Expiry Monitor Service.\r\nhttps://" . $current_link . "";
       $message = wordwrap($message, 70, "\r\n");
       $headers = 'From: noreply@' . $current_domain . "\r\n" .
           'Reply-To: noreply@' . $current_domain . "\r\n" .
           'Return-Path: noreply@' . $current_domain . "\r\n" .
           'X-Visitor-IP: ' . $visitor_ip . "\r\n" .
           'X-Coffee: Black' . "\r\n" .
-          'List-Unsubscribe: <https://' . $current_domain . "/unsubscribe.php?id=" . $id . ">" . "\r\n" .
+          'List-Unsubscribe: <https://' . $current_link . "/unsubscribe.php?id=" . $id . ">" . "\r\n" .
           'X-Mailer: PHP/4.1.1';  
 
       if (mail($to, $subject, $message, $headers) === true) {

--- a/functions/pre_check.php
+++ b/functions/pre_check.php
@@ -16,6 +16,7 @@
 
 function add_domain_to_pre_check($domain,$email,$visitor_ip) {
     global $current_domain;
+    global $current_link;
     global $pre_check_file;
     global $check_file;
     $result = array();
@@ -72,7 +73,7 @@ function add_domain_to_pre_check($domain,$email,$visitor_ip) {
         return $result;
     }
 
-    $sublink = "https://" . $current_domain . "/confirm.php?id=" . $uuid;
+    $sublink = "https://" . $current_link . "/confirm.php?id=" . $uuid;
 
     $to      = $email;
     $subject = "Confirm your Certificate Expiry Monitor subscription for " . htmlspecialchars($domain) . ".";
@@ -83,7 +84,7 @@ function add_domain_to_pre_check($domain,$email,$visitor_ip) {
         'Return-Path: noreply@' . $current_domain . "\r\n" .
         'X-Visitor-IP: ' . $visitor_ip . "\r\n" .
         'X-Coffee: Black' . "\r\n" .
-        'List-Unsubscribe: <https://' . $current_domain . "/unsubscribe.php?id=" . $uuid . ">" . "\r\n" .
+        'List-Unsubscribe: <https://' . $current_link . "/unsubscribe.php?id=" . $uuid . ">" . "\r\n" .
         'X-Mailer: PHP/4.1.1';
 
     

--- a/functions/remove_check.php
+++ b/functions/remove_check.php
@@ -16,6 +16,7 @@
 
 function remove_domain_check($id,$visitor_ip) {
     global $current_domain;
+    global $current_link;
     global $check_file;
     global $deleted_check_file;
     $result = array();
@@ -76,18 +77,18 @@ function remove_domain_check($id,$visitor_ip) {
             return $result;
         }
 
-        $link = "https://" . $current_domain . "/";
+        $link = "https://" . $current_link . "/";
 
         $to      = $deleted_json_a[$id]['email'];
         $subject = "Certificate Expiry Monitor subscription removed for " . htmlspecialchars($deleted_json_a[$id]['domain']) . ".";
-        $message = "Hello,\r\n\r\nYou have removed the subscription of a  website to the Certificate Expiry Monitor.\r\n\r\nDomain: " . trim(htmlspecialchars($deleted_json_a[$id]['domain'])) . "\r\nEmail: " . trim(htmlspecialchars($deleted_json_a[$id]['email'])) . "\r\nIP subscription removed from: " . htmlspecialchars($visitor_ip) . "\r\nDate subscribed removed: " . date("Y-m-d H:i:s") . "\r\n\r\nWe will not monitor this website any longer and you will not receive any emails whatsoever from us again for this domain. Do note that you might miss an expiring certificate.\r\n\r\nTo re-subscribe this domain please add it again on the Certificate Expiry Monitor website: \r\n\r\n  " . $link . "\r\n\r\nHave a nice day,\r\nThe Certificate Expiry Monitor Service.\r\nhttps://" . $current_domain . "";
+        $message = "Hello,\r\n\r\nYou have removed the subscription of a  website to the Certificate Expiry Monitor.\r\n\r\nDomain: " . trim(htmlspecialchars($deleted_json_a[$id]['domain'])) . "\r\nEmail: " . trim(htmlspecialchars($deleted_json_a[$id]['email'])) . "\r\nIP subscription removed from: " . htmlspecialchars($visitor_ip) . "\r\nDate subscribed removed: " . date("Y-m-d H:i:s") . "\r\n\r\nWe will not monitor this website any longer and you will not receive any emails whatsoever from us again for this domain. Do note that you might miss an expiring certificate.\r\n\r\nTo re-subscribe this domain please add it again on the Certificate Expiry Monitor website: \r\n\r\n  " . $link . "\r\n\r\nHave a nice day,\r\nThe Certificate Expiry Monitor Service.\r\nhttps://" . $current_link . "";
         $message = wordwrap($message, 70, "\r\n");
         $headers = 'From: noreply@' . $current_domain . "\r\n" .
             'Reply-To: noreply@' . $current_domain . "\r\n" .
             'Return-Path: noreply@' . $current_domain . "\r\n" .
             'X-Visitor-IP: ' . $visitor_ip . "\r\n" .
             'X-Coffee: Black' . "\r\n" .
-            'List-Unsubscribe: <https://' . $current_domain . "/unsubscribe.php?id=" . $id . ">" . "\r\n" .
+            'List-Unsubscribe: <https://' . $current_link . "/unsubscribe.php?id=" . $id . ">" . "\r\n" .
             'X-Mailer: PHP/4.1.1';
 
         if (mail($to, $subject, $message, $headers) === true) {

--- a/functions/variables.php
+++ b/functions/variables.php
@@ -29,6 +29,7 @@ ini_set('default_socket_timeout', 2);
 $random_blurp = rand(1000,99999);
 
 $current_domain = "certificatemonitor.org";
+$current_link = "certificatemonitor.org";
 
 // set this to a location outside of your webroot so that it cannot be accessed via the internets.
 


### PR DESCRIPTION
With $current_domain used for the domain part of the email address as well as the links, the app needs to be installed to the root of the webserver. These changes allow a different domain or a subdirectory to be used.