### PR TITLE
Visitor IP is missing when manually unsubscribing

### DIFF
--- a/unsubscribe.php
+++ b/unsubscribe.php
@@ -29,7 +29,7 @@ if ( isset($_GET['id']) && !empty($_GET['id'])  ) {
     $cron = htmlspecialchars($_GET['cron']);
   } 
   if ($cron == "auto") {
-    $userip = "Removed automatically because to many errors occured.";
+    $userip = "Removed automatically because too many errors occured.";
   }
   $uuid_pattern = "/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/";
   if (preg_match($uuid_pattern, $id)) {

--- a/unsubscribe.php
+++ b/unsubscribe.php
@@ -28,7 +28,7 @@ if ( isset($_GET['id']) && !empty($_GET['id'])  ) {
   if ( isset($_GET['cron']) && !empty($_GET['cron'])  ) {
     $cron = htmlspecialchars($_GET['cron']);
   } 
-  if ($cron = "auto") {
+  if ($cron == "auto") {
     $userip = "Removed automatically because to many errors occured.";
   }
   $uuid_pattern = "/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/";


### PR DESCRIPTION
I noticed that my IP address was not included when I manually unsubscribed from receiving alerts for a domain. After digging, I discovered that the check to see if the request was initiated via `cron` was not actually performing an equality check, but rather an assignment, causing it to always return the same message. I’m guessing that manually unsubscribing is not performed very often, which would explain why this bug has lingered.

I also fixed a typo.